### PR TITLE
Items create endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Simplecov coverage file ignore
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 5.1.2'
   gem 'shoulda-matchers'
+  gem 'simplecov'
 end
 
 group :development do

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,0 +1,14 @@
+class ItemsController < ApplicationController
+  def create
+    @item = Item.new(item_params)
+    if @item.save
+      render json: @item
+    end
+  end
+
+  private
+
+  def item_params
+    params.require(:item).permit(:name, :weight_lb, :count)
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,4 @@
 class Item < ApplicationRecord
   validates_presence_of :name
   validates_presence_of :weight_lb
-  validates_presence_of :count
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  get 'items', to: 'items#create'
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Item, type: :model do
       expect(subject).to_not be_valid
     end
 
-    it "is not valid without a count" do
+    it "is valid without a count" do
       subject.count = nil
-      expect(subject).to_not be_valid
+      expect(subject).to be_valid
     end
 
     it "is valid without a count of 0" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'

--- a/spec/requests/api/item/create_spec.rb
+++ b/spec/requests/api/item/create_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe "Items", type: :request do
+  describe "Create Spec:" do
+    it "Can be created" do
+      expect(Item.all.size).to eq(0)
+
+      get "/items", params: {
+        item: {
+          name: "Guitar",
+          weight_lb: 5,
+          count: 1
+        }
+      }
+
+      expect(Item.all.size).to eq(1)
+
+      item = Item.first
+
+      expect(item).to be_an(Item)
+      expect(item.name).to eq("Guitar")
+      expect(item.weight_lb).to eq(5)
+      expect(item.count).to eq(1)
+    end
+
+    it "Can be created without count" do
+      expect(Item.all.size).to eq(0)
+
+      get "/items", params: {
+        item: {
+          name: "Guitar",
+          weight_lb: 5
+        }
+      }
+
+      expect(Item.all.size).to eq(1)
+
+      item = Item.first
+      expect(item.count).to eq(nil)
+    end
+
+    it "Cannot be created without name" do
+      expect(Item.all.size).to eq(0)
+
+      get "/items", params: {
+        item: {
+          weight_lb: 5,
+          count: 1
+        }
+      }
+
+      expect(Item.all.size).to eq(0)
+    end
+
+    it "Cannot be created without weight_lb" do
+      expect(Item.all.size).to eq(0)
+
+      get "/items", params: {
+        item: {
+          name: "Guitar",
+          count: 1
+        }
+      }
+
+      expect(Item.all.size).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
**What was changed:**
Added simplecov gem to monitor test coverage

A new endpoint '/items' can be used to create an item with three attributes: 'name', 'weight_lb', and an optional 'count'

**Checklist:**
- [x] Feature is thoroughly tested
- [x] Labels added to PR

**List any issues being closed by this PR:**
closes #3 