### PR TITLE
Warehouse Create Endpoint

### DIFF
--- a/app/controllers/warehouses_controller.rb
+++ b/app/controllers/warehouses_controller.rb
@@ -1,0 +1,16 @@
+class WarehousesController < ApplicationController
+  def create
+    @warehouse = Warehouse.new(warehouse_params)
+    if @warehouse.save
+      render json: @warehouse
+    else
+      render json: {"errors": @warehouse.errors.full_messages}
+    end
+  end
+  
+  private
+
+  def warehouse_params
+    params.require(:warehouse).permit(:name, :location, :capacity)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :items, :only => [:index, :create, :edit]
+
+  post "/warehouses", to: "warehouses#create"
 end

--- a/db/migrate/20220514195307_create_items.rb
+++ b/db/migrate/20220514195307_create_items.rb
@@ -3,7 +3,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
     create_table :items do |t|
       t.string :name
       t.float :weight_lb
-      t.integer :count
+      t.integer :count, :default => 1
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema.define(version: 2022_05_15_153305) do
   create_table "items", force: :cascade do |t|
     t.string "name"
     t.float "weight_lb"
-    t.integer "count"
+    t.integer "count", default: 1
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "warehouse_id"

--- a/spec/requests/item/create_spec.rb
+++ b/spec/requests/item/create_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Items", type: :request do
       expect(json[:count]).to eq(1)
     end
 
-    it "Can be created without count" do
+    it "Count is 1 when no count specified" do
       expect(Item.all.size).to eq(0)
 
       post "/items", params: {
@@ -42,13 +42,13 @@ RSpec.describe "Items", type: :request do
       expect(Item.all.size).to eq(1)
 
       item = Item.first
-      expect(item.count).to eq(nil)
+      expect(item.count).to eq(1)
 
       json = JSON.parse(response.body, symbolize_names: true)
 
       expect(json[:name]).to eq("Guitar")
       expect(json[:weight_lb]).to eq(5)
-      expect(json[:count]).to eq(nil)
+      expect(json[:count]).to eq(1)
     end
 
     it "Cannot be created without name" do

--- a/spec/requests/item/index_spec.rb
+++ b/spec/requests/item/index_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Items", type: :request do
   describe "Index Spec:" do
     it "Can get list of all items" do
       expect(Item.all.size).to eq(0)
-
+ 
       Item.create(name:"Donut", weight_lb:0.5)
       Item.create(name:"Hat", weight_lb:0.25)
       Item.create(name:"Iphone", weight_lb:1)

--- a/spec/requests/warehouse/create_spec.rb
+++ b/spec/requests/warehouse/create_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe "Warehouses", type: :request do
+  describe "Create Spec:" do
+    it "Can be created" do
+      expect(Item.all.size).to eq(0)
+
+      post "/warehouses", params: {
+        warehouse: {
+          name: "Amazon Distribution Center",
+          location: "1234 AMZN Way",
+          capacity: 10000
+        }
+      }
+
+      expect(Warehouse.all.size).to eq(1)
+
+      warehouse = Warehouse.first
+
+      expect(warehouse).to be_a(Warehouse)
+      expect(warehouse.name).to eq("Amazon Distribution Center")
+      expect(warehouse.location).to eq("1234 AMZN Way")
+      expect(warehouse.capacity).to eq(10000)
+
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json[:name]).to eq("Amazon Distribution Center")
+      expect(json[:location]).to eq("1234 AMZN Way")
+      expect(json[:capacity]).to eq(10000)
+    end
+
+    it "Cannot be created without name" do
+      expect(Item.all.size).to eq(0)
+
+      post "/warehouses", params: {
+        warehouse: {
+          location: "1234 AMZN Way",
+          capacity: 10000
+        }
+      }
+
+      expect(Warehouse.all.size).to eq(0)
+
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json[:errors]).to eq(["Name can't be blank"])
+    end
+
+    it "Cannot be created without location" do
+      expect(Item.all.size).to eq(0)
+
+      post "/warehouses", params: {
+        warehouse: {
+          name: "Amazon Distribution Center",
+          capacity: 10000
+        }
+      }
+
+      expect(Item.all.size).to eq(0)
+
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json[:errors]).to eq(["Location can't be blank"])
+    end
+
+    it "Cannot be created without capacity" do
+      expect(Item.all.size).to eq(0)
+
+      post "/warehouses", params: {
+        warehouse: {
+          name: "Amazon Distribution Center",
+          location: "1234 AMZN Way"
+        }
+      }
+
+      expect(Warehouse.all.size).to eq(0)
+
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json[:errors]).to eq(["Capacity can't be blank"])
+    end
+  end
+end


### PR DESCRIPTION
**What was changed:**
A warehouse can now be created through an API request
item now has a default count of 1

**Checklist:**
- [x] Feature is thoroughly tested
- [x] Labels added to PR

**List any issues being closed by this PR:**
closes #10 