### PR TITLE
Refactor Tests, Take nesting out of create item params

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,7 +19,7 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
-    if @item.update(item_params)
+    if @item.update(strict_item_params)
       render json: @item
     else
       render json: {"errors": @item.errors.full_messages}
@@ -29,6 +29,10 @@ class ItemsController < ApplicationController
   private
 
   def item_params
+    params.permit(:name, :weight_lb, :count)
+  end
+
+  def strict_item_params
     params.require(:item).permit(:name, :weight_lb, :count)
   end
 end

--- a/spec/requests/item/create_spec.rb
+++ b/spec/requests/item/create_spec.rb
@@ -5,12 +5,10 @@ RSpec.describe "Items", type: :request do
     it "Can be created" do
       expect(Item.all.size).to eq(0)
 
-      post "/items", params: {
-        item: {
-          name: "Guitar",
-          weight_lb: 5,
-          count: 1
-        }
+      get "/items/new", params: {
+        name: "Guitar",
+        weight_lb: 5,
+        count: 1
       }
 
       expect(Item.all.size).to eq(1)
@@ -32,11 +30,9 @@ RSpec.describe "Items", type: :request do
     it "Count is 1 when no count specified" do
       expect(Item.all.size).to eq(0)
 
-      post "/items", params: {
-        item: {
-          name: "Guitar",
-          weight_lb: 5
-        }
+      get "/items/new", params: {
+        name: "Guitar",
+        weight_lb: 5
       }
 
       expect(Item.all.size).to eq(1)
@@ -54,11 +50,9 @@ RSpec.describe "Items", type: :request do
     it "Cannot be created without name" do
       expect(Item.all.size).to eq(0)
 
-      post "/items", params: {
-        item: {
-          weight_lb: 5,
-          count: 1
-        }
+      get "/items/new", params: {
+        weight_lb: 5,
+        count: 1
       }
 
       expect(Item.all.size).to eq(0)
@@ -71,11 +65,9 @@ RSpec.describe "Items", type: :request do
     it "Cannot be created without weight_lb" do
       expect(Item.all.size).to eq(0)
 
-      post "/items", params: {
-        item: {
-          name: "Guitar",
-          count: 1
-        }
+      get "/items/new", params: {
+        name: "Guitar",
+        count: 1
       }
 
       expect(Item.all.size).to eq(0)

--- a/spec/requests/warehouse/create_spec.rb
+++ b/spec/requests/warehouse/create_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Warehouses", type: :request do
     it "Can be created" do
       expect(Item.all.size).to eq(0)
 
-      post "/warehouses", params: {
+      get "/warehouses/new", params: {
         warehouse: {
           name: "Amazon Distribution Center",
           location: "1234 AMZN Way",
@@ -32,7 +32,7 @@ RSpec.describe "Warehouses", type: :request do
     it "Cannot be created without name" do
       expect(Item.all.size).to eq(0)
 
-      post "/warehouses", params: {
+      get "/warehouses/new", params: {
         warehouse: {
           location: "1234 AMZN Way",
           capacity: 10000
@@ -49,7 +49,7 @@ RSpec.describe "Warehouses", type: :request do
     it "Cannot be created without location" do
       expect(Item.all.size).to eq(0)
 
-      post "/warehouses", params: {
+      get "/warehouses/new", params: {
         warehouse: {
           name: "Amazon Distribution Center",
           capacity: 10000
@@ -66,7 +66,7 @@ RSpec.describe "Warehouses", type: :request do
     it "Cannot be created without capacity" do
       expect(Item.all.size).to eq(0)
 
-      post "/warehouses", params: {
+      get "/warehouses/new", params: {
         warehouse: {
           name: "Amazon Distribution Center",
           location: "1234 AMZN Way"


### PR DESCRIPTION
**What was changed:**
item params no longer need to be nested under item keyword
Tests reflect changes

**Checklist:**
- [x] Feature is thoroughly tested
- [x] Labels added to PR

**List any issues being closed by this PR:**
